### PR TITLE
 add multi-platform CI/CD templates (GitLab, Azure DevOps, Jenkins

### DIFF
--- a/docs/CI_CD_INTEGRATION.md
+++ b/docs/CI_CD_INTEGRATION.md
@@ -1,0 +1,110 @@
+# CI/CD Integration Guide
+
+Integrate Inkog into your CI/CD pipelines to ensure automated security and logic checks on every commit or merge request. All our CI/CD templates produce SARIF files, enabling native integration with your platform's security dashboards.
+
+## GitHub Actions
+
+Use the official Inkog GitHub Action:
+
+```yaml
+name: Inkog Security Scan
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inkog Scan
+        uses: inkog-io/inkog@v1
+        with:
+          api-key: ${{ secrets.INKOG_API_KEY }}
+          sarif-upload: true
+          policy: balanced
+          severity: low
+          path: .
+```
+
+## GitLab CI
+
+GitLab has native SARIF support in its Security Dashboard. You can upload Inkog's SARIF output as a SAST report artifact.
+Add the following to your `.gitlab-ci.yml`:
+
+> **Note:** Ensure you add `INKOG_API_KEY` as a masked variable in your GitLab CI/CD Settings!
+
+```yaml
+variables:
+  INKOG_POLICY: "balanced"
+  INKOG_PATH: "."
+  INKOG_SEVERITY: "low"
+
+inkog-scan:
+  stage: test
+  image: ghcr.io/inkog-io/inkog:latest
+  script:
+    - inkog -path $INKOG_PATH -policy $INKOG_POLICY -severity $INKOG_SEVERITY -output sarif > gl-inkog-results.sarif
+  artifacts:
+    reports:
+      sast: gl-inkog-results.sarif
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+```
+
+## Azure DevOps
+
+Azure DevOps can view SARIF files using the [SARIF viewer extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans).
+Add this task to your `azure-pipelines.yml`:
+
+> **Note:** Map your `INKOG_API_KEY` secret variable to the environment variable!
+
+```yaml
+variables:
+  INKOG_POLICY: 'balanced'
+  INKOG_PATH: '$(Build.SourcesDirectory)'
+  INKOG_SEVERITY: 'low'
+
+steps:
+- task: Bash@3
+  displayName: 'Inkog Security Scan'
+  inputs:
+    targetType: 'inline'
+    script: |
+      curl -fsSL https://get.inkog.io | sh
+      inkog -path $(INKOG_PATH) -policy $(INKOG_POLICY) -severity $(INKOG_SEVERITY) -output sarif > $(Build.ArtifactStagingDirectory)/inkog.sarif
+  env:
+    INKOG_API_KEY: $(INKOG_API_KEY)
+```
+
+## Jenkins
+
+For Jenkins, use the Warnings Next Generation plugin to read SARIF output.
+Add the following stage to your `Jenkinsfile`:
+
+> **Note:** Make sure you have added your Inkog API key to your Jenkins credentials.
+
+```groovy
+pipeline {
+    agent any
+    environment {
+        INKOG_API_KEY = credentials('inkog-api-key')
+        INKOG_POLICY = 'balanced'
+        INKOG_PATH = '.'
+        INKOG_SEVERITY = 'low'
+    }
+    stages {
+        stage('Inkog Security Scan') {
+            steps {
+                sh 'curl -fsSL https://get.inkog.io | sh'
+                sh 'inkog -path ${INKOG_PATH} -policy ${INKOG_POLICY} -severity ${INKOG_SEVERITY} -output sarif > inkog-results.sarif'
+            }
+        }
+    }
+    post {
+        always {
+            recordIssues(tools: [sarif(pattern: 'inkog-results.sarif')])
+        }
+    }
+}
+```

--- a/examples/ci/.gitlab-ci.yml
+++ b/examples/ci/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+variables:
+  INKOG_POLICY: "balanced"
+  INKOG_PATH: "."
+  INKOG_SEVERITY: "low"
+
+inkog-scan:
+  stage: test
+  image: ghcr.io/inkog-io/inkog:latest
+  script:
+    - inkog -path $INKOG_PATH -policy $INKOG_POLICY -severity $INKOG_SEVERITY -output sarif > gl-inkog-results.sarif
+  artifacts:
+    reports:
+      sast: gl-inkog-results.sarif
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'

--- a/examples/ci/Jenkinsfile
+++ b/examples/ci/Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+    environment {
+        INKOG_API_KEY = credentials('inkog-api-key')
+        INKOG_POLICY = 'balanced'
+        INKOG_PATH = '.'
+        INKOG_SEVERITY = 'low'
+    }
+    stages {
+        stage('Inkog Security Scan') {
+            steps {
+                sh 'curl -fsSL https://get.inkog.io | sh'
+                sh 'inkog -path ${INKOG_PATH} -policy ${INKOG_POLICY} -severity ${INKOG_SEVERITY} -output sarif > inkog-results.sarif'
+            }
+        }
+    }
+    post {
+        always {
+            recordIssues(tools: [sarif(pattern: 'inkog-results.sarif')])
+        }
+    }
+}

--- a/examples/ci/azure-pipelines.yml
+++ b/examples/ci/azure-pipelines.yml
@@ -1,0 +1,15 @@
+variables:
+  INKOG_POLICY: 'balanced'
+  INKOG_PATH: '$(Build.SourcesDirectory)'
+  INKOG_SEVERITY: 'low'
+
+steps:
+- task: Bash@3
+  displayName: 'Inkog Security Scan'
+  inputs:
+    targetType: 'inline'
+    script: |
+      curl -fsSL https://get.inkog.io | sh
+      inkog -path $(INKOG_PATH) -policy $(INKOG_POLICY) -severity $(INKOG_SEVERITY) -output sarif > $(Build.ArtifactStagingDirectory)/inkog.sarif
+  env:
+    INKOG_API_KEY: $(INKOG_API_KEY)


### PR DESCRIPTION

Currently, Inkog only provides a GitHub Actions workflow for CI/CD integration. Many enterprise teams using GitLab CI, Azure DevOps, or Jenkins have no ready-made pipeline templates, which forces manual setup and slows down adoption. 

This PR introduces out-of-the-box CI/CD templates for the major enterprise platforms and maps Inkog's core CLI options (policy, severity, path) to their respective pipeline variable syntaxes. It also configures them to natively ingest SARIF reports directly into their security dashboards.

## Changes Included
* 🦊 **GitLab CI**: Added [.gitlab-ci.yml](cci:7://file:///c:/Users/Monssef/inkog/examples/ci/.gitlab-ci.yml:0:0-0:0) template that uploads SAST artifacts directly to GitLab's Native Security Dashboard.
* ☁️ **Azure DevOps**: Added [azure-pipelines.yml](cci:7://file:///c:/Users/Monssef/inkog/examples/ci/azure-pipelines.yml:0:0-0:0) demonstrating how to run inline bash steps and store artifacts for the SARIF viewer extension.
* 🏗️ **Jenkins**: Added a declarative [Jenkinsfile](cci:7://file:///c:/Users/Monssef/inkog/examples/ci/Jenkinsfile:0:0-0:0) demonstrating credentials binding and publishing results to the Warnings Next Generation plugin.
* 📚 **Documentation**: Added a comprehensive [CI_CD_INTEGRATION.md](cci:7://file:///c:/Users/Monssef/inkog/docs/CI_CD_INTEGRATION.md:0:0-0:0) guide with setup instructions covering all integrations in one place.

## Motivation and Context
These templates provide table-stakes functionality for enterprise adoption. It demonstrates that our scanner logic (install Inkog, run scan, upload SARIF artifact) is identical and easily integrated across any CI platform, while bridging the gap between [action.yml](cci:7://file:///c:/Users/Monssef/inkog/action.yml:0:0-0:0) and other platforms.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
issue:#5
