### PR TITLE
chore(changelog): v1.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-04-29
+
+A documentation refresh and infrastructure patch. No changes to detection logic — scan results are identical to v1.2.0.
+
+### Added
+- **CHANGELOG.md** — release history covering v1.0.0 → v1.2.0 in Keep a Changelog format
+- **Dependabot** — weekly automated updates for Go modules and GitHub Actions
+- **Framework-support issue template** — checklist for detection categories and example agent code
+
+### Changed
+- **GitHub Action** (`inkog-io/inkog@v1`) — downloads pre-built binaries instead of building from source; CI scans run ~10× faster (~60s → ~5s, supports macOS/Linux/Windows + amd64/arm64)
+- **CONTRIBUTING.md** — rewritten with Universal IR primer and clearer adapter-contribution guide
+- **SECURITY.md** — adds supported versions table, points to GitHub Security Advisories, expands scope to cover the MCP server and GitHub Action
+
 ## [1.2.0] — 2026-04-13
 
 ### Added
@@ -68,7 +82,8 @@ Initial public release.
 - **Multi-framework support** — LangChain, LangGraph, CrewAI, AutoGen, OpenAI Agents, Semantic Kernel, LlamaIndex, Haystack, DSPy, Phidata, Smolagents, PydanticAI, Google ADK, n8n, Flowise, Langflow, Dify, Microsoft Copilot Studio, Salesforce Agentforce.
 - **Cross-platform builds** — darwin (amd64, arm64), linux (amd64, arm64), windows (amd64).
 
-[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/inkog-io/inkog/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/inkog-io/inkog/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/inkog-io/inkog/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/inkog-io/inkog/releases/tag/v1.0.0


### PR DESCRIPTION
Moves the v1.2.1 changes into a dated `## [1.2.1] — 2026-04-29` section and resets `[Unreleased]` to empty for the next cycle. Version-compare links at the bottom of the file are updated to point to `v1.2.1` as the new base.

GitHub release page: https://github.com/inkog-io/inkog/releases/tag/v1.2.1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnnUiouodqJwqdVgV8GbTn)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish v1.2.1 release notes in CHANGELOG: move Unreleased items into a dated 1.2.1 section and reset Unreleased for the next cycle. Update compare links to use v1.2.1 as the base; docs-only, no code or behavior changes.

<sup>Written for commit dd77a0b83af4c94e0fa9019fa2a967e130283060. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

