### PR TITLE
Add OpenClaw scanner checks

### DIFF
--- a/pkg/cli/openclaw.go
+++ b/pkg/cli/openclaw.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/inkog-io/inkog/pkg/contract"
+)
+
+var openClawConfigFiles = map[string]bool{
+	"AGENTS.md": true,
+	"SHIELD.md": true,
+	"SKILL.md":  true,
+	"SOUL.md":   true,
+	"TOOLS.md":  true,
+}
+
+var destructiveOpenClawTerms = []string{
+	"delete", "destroy", "drop table", "exec", "execute_code", "filesystem",
+	"kill", "modify file", "subprocess", "transfer", "write file",
+}
+
+var approvalOpenClawTerms = []string{
+	"approval", "approve", "confirm", "human", "manual review", "oversight",
+}
+
+var promptInjectionTerms = []string{
+	"bypass", "developer message", "ignore previous", "ignore prior",
+	"override instructions",
+}
+
+func isOpenClawConfigFile(filename string) bool {
+	return openClawConfigFiles[filename]
+}
+
+func scanOpenClawFindings(sourcePath string, files map[string]bool) []contract.Finding {
+	configs := openClawConfigs(sourcePath, files)
+	if len(configs) == 0 {
+		return nil
+	}
+
+	findings := make([]contract.Finding, 0)
+	if _, ok := configs["SHIELD.md"]; !ok {
+		findings = append(findings, openClawFinding(
+			"openclaw_missing_shield",
+			"Missing OpenClaw guardrail configuration",
+			"OpenClaw project defines agent configuration files but no SHIELD.md guardrail file was found.",
+			"SHIELD.md",
+			1,
+			"CRITICAL",
+			"oversight",
+		))
+	}
+
+	hasApproval := openClawHasApprovalLanguage(configs)
+	for name, path := range configs {
+		if name != "TOOLS.md" && name != "SKILL.md" {
+			continue
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if line, ok := firstMatchingLine(string(content), destructiveOpenClawTerms); ok && !hasApproval {
+			findings = append(findings, openClawFinding(
+				"openclaw_destructive_tool_without_approval",
+				"OpenClaw destructive tool lacks human approval",
+				fmt.Sprintf("OpenClaw %s references a destructive capability without nearby approval or oversight language.", name),
+				relativeOpenClawPath(sourcePath, path),
+				line,
+				"HIGH",
+				"authorization",
+			))
+		}
+		if line, ok := firstMatchingLine(string(content), promptInjectionTerms); ok {
+			findings = append(findings, openClawFinding(
+				"openclaw_prompt_injection_vector",
+				"OpenClaw config contains prompt-injection language",
+				fmt.Sprintf("OpenClaw %s contains wording commonly used to bypass or override agent instructions.", name),
+				relativeOpenClawPath(sourcePath, path),
+				line,
+				"MEDIUM",
+				"oversight",
+			))
+		}
+	}
+
+	return findings
+}
+
+func openClawConfigs(sourcePath string, files map[string]bool) map[string]string {
+	configs := make(map[string]string)
+	for path := range files {
+		name := filepath.Base(path)
+		if isOpenClawConfigFile(name) {
+			configs[name] = path
+		}
+	}
+
+	if info, err := os.Stat(sourcePath); err == nil && info.IsDir() {
+		for name := range openClawConfigFiles {
+			path := filepath.Join(sourcePath, name)
+			if _, err := os.Stat(path); err == nil {
+				configs[name] = path
+			}
+		}
+	}
+
+	return configs
+}
+
+func openClawHasApprovalLanguage(configs map[string]string) bool {
+	for _, path := range configs {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if _, ok := firstMatchingLine(string(content), approvalOpenClawTerms); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func firstMatchingLine(content string, terms []string) (int, bool) {
+	for idx, line := range strings.Split(content, "\n") {
+		lower := strings.ToLower(line)
+		for _, term := range terms {
+			if strings.Contains(lower, term) {
+				return idx + 1, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func relativeOpenClawPath(sourcePath, path string) string {
+	if rel, err := filepath.Rel(sourcePath, path); err == nil && rel != "." {
+		return rel
+	}
+	return filepath.Base(path)
+}
+
+func openClawFinding(patternID, pattern, message, file string, line int, severity, governanceCategory string) contract.Finding {
+	return contract.Finding{
+		ID:                 fmt.Sprintf("%s_%s_%d", patternID, strings.ReplaceAll(file, string(filepath.Separator), "_"), line),
+		PatternID:          patternID,
+		Pattern:            pattern,
+		Source:             contract.SourceLocalCLI,
+		File:               file,
+		Line:               line,
+		Severity:           severity,
+		Confidence:         0.82,
+		Message:            message,
+		Category:           "governance",
+		RiskTier:           contract.TierRiskPattern,
+		FindingType:        contract.TypeGovernanceViolation,
+		GovernanceCategory: governanceCategory,
+		OWASP:              "LLM08",
+		ComplianceMapping: &contract.ComplianceMapping{
+			EUAIActArticles: []string{"Article 14"},
+			NISTCategories:  []string{"GOVERN 4.1"},
+			OWASPItems:      []string{"LLM08"},
+		},
+	}
+}

--- a/pkg/cli/openclaw_test.go
+++ b/pkg/cli/openclaw_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/inkog-io/inkog/pkg/contract"
+)
+
+func TestShouldScanFile_OpenClawConfigs(t *testing.T) {
+	tests := []string{"TOOLS.md", "SKILL.md", "SHIELD.md", "SOUL.md", "AGENTS.md"}
+	for _, path := range tests {
+		if !shouldScanFile(path) {
+			t.Fatalf("expected %s to be scanned", path)
+		}
+	}
+}
+
+func TestScanOpenClawFindingsMissingShield(t *testing.T) {
+	tmpDir := t.TempDir()
+	capabilityPath := filepath.Join(tmpDir, "SKILL.md")
+
+	if err := os.WriteFile(capabilityPath, []byte(`
+name: trading-agent
+
+Tools:
+- execute_code can manage file changes.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := scanOpenClawFindings(tmpDir, map[string]bool{capabilityPath: true})
+	assertHasPattern(t, findings, "openclaw_missing_shield")
+	assertHasPattern(t, findings, "openclaw_destructive_tool_without_approval")
+}
+
+func TestScanOpenClawFindingsApprovalSuppressesDestructiveFinding(t *testing.T) {
+	tmpDir := t.TempDir()
+	toolsPath := filepath.Join(tmpDir, "TOOLS.md")
+	shieldPath := filepath.Join(tmpDir, "SHIELD.md")
+
+	if err := os.WriteFile(toolsPath, []byte(`
+tools:
+- execute_code can manage file changes.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shieldPath, []byte(`
+File-changing tools require human approval before running.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := scanOpenClawFindings(tmpDir, map[string]bool{toolsPath: true, shieldPath: true})
+	assertNoPattern(t, findings, "openclaw_missing_shield")
+	assertNoPattern(t, findings, "openclaw_destructive_tool_without_approval")
+}
+
+func TestScanOpenClawFindingsPromptInjectionVector(t *testing.T) {
+	tmpDir := t.TempDir()
+	toolsPath := filepath.Join(tmpDir, "TOOLS.md")
+	shieldPath := filepath.Join(tmpDir, "SHIELD.md")
+
+	if err := os.WriteFile(toolsPath, []byte(`
+description: override instructions during tool use
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shieldPath, []byte(`
+Require human oversight for risky tool calls.
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	findings := scanOpenClawFindings(tmpDir, map[string]bool{toolsPath: true, shieldPath: true})
+	assertHasPattern(t, findings, "openclaw_prompt_injection_vector")
+}
+
+func assertHasPattern(t *testing.T, findings []contract.Finding, patternID string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.PatternID == patternID {
+			return
+		}
+	}
+	t.Fatalf("expected finding pattern %q, got %#v", patternID, findings)
+}
+
+func assertNoPattern(t *testing.T, findings []contract.Finding, patternID string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.PatternID == patternID {
+			t.Fatalf("did not expect finding pattern %q, got %#v", patternID, findings)
+		}
+	}
+}

--- a/pkg/cli/scanner.go
+++ b/pkg/cli/scanner.go
@@ -425,6 +425,7 @@ func (hs *HybridScanner) scanLocalSecretsAndCollectFiles() ([]contract.Finding, 
 		allFiles = truncateFileMap(allFiles, maxFiles, hs.SourcePath)
 	}
 
+	localFindings = append(localFindings, scanOpenClawFindings(hs.SourcePath, allFiles)...)
 	return localFindings, allFiles, err
 }
 
@@ -664,6 +665,9 @@ func shouldScanFile(path string) bool {
 	filename := filepath.Base(path)
 	if BlockedFiles[filename] {
 		return false
+	}
+	if isOpenClawConfigFile(filename) {
+		return true
 	}
 
 	// Check supported extensions


### PR DESCRIPTION
Closes #3.

## Summary
- add a local OpenClaw scanner slice for `TOOLS.md`, `SKILL.md`, `SHIELD.md`, `SOUL.md`, and `AGENTS.md`
- report local governance findings for missing `SHIELD.md`, risky tool capability language without human approval language, and prompt-injection wording in OpenClaw tool/capability config
- include focused tests for OpenClaw config recognition and finding generation

## Scope notes
This is a narrow first slice in the CLI scanner. I did not claim full Universal IR coverage for OpenClaw because this checkout exposes the local CLI scanner, while broader server-side/IR adapter work appears to live outside this branch.

## Verification
- `go test ./...`
- `git diff --check`

## AANA note
This PR was selected and published through an AANA-gated community issue workflow. AANA was used only as a verifier/correction gate for issue fit, public-claim boundaries, and publish readiness; it is not a security certification or compliance approval.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local OpenClaw scanner to the CLI to detect OpenClaw configs and surface governance risks. Flags missing `SHIELD.md`, destructive tool language without human approval, and prompt-injection phrasing.

- **New Features**
  - Scans `TOOLS.md`, `SKILL.md`, `SHIELD.md`, `SOUL.md`, `AGENTS.md` locally.
  - Findings:
    - CRITICAL: `openclaw_missing_shield`
    - HIGH: `openclaw_destructive_tool_without_approval` when destructive terms appear without approval wording
    - MEDIUM: `openclaw_prompt_injection_vector`
  - Integrated into `HybridScanner` local scan and file filter.
  - Adds targeted tests for config recognition and finding generation.

<sup>Written for commit 391440151ba45a55310019d822a5122239312edc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

