### PR TITLE
data: scan corpus refresh — 2026-05-17

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,12 @@
+{
+  "_description": "Failed scan attempts during corpus refresh. Each entry records the repo, timestamp, HTTP status, and error reason.",
+  "failures": [
+    {
+      "timestamp": "2026-05-17T19:31:58Z",
+      "repo": "szybnev/DVLA",
+      "http_status": 400,
+      "reason": "no_agent_code",
+      "error_response": {"error": "no_agent_code", "code": "no_agent_code"}
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.7,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-05-17T19:31:58Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-05-17T19:31:58Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "ce8098b0-2de9-402e-89aa-5f8a3bb6f253",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned `merlvintan/damn-vulnerable-llm-agent`: 2 findings (HIGH ×2), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`.

`szybnev/DVLA` was attempted first but returned `no_agent_code` (400); failure logged in `data/scan-corpus-failures.json`.

Corpus grows from 2 → 3 entries; aggregate governance score moves from 16.0 → 19.7.

---
_Generated by [Claude Code](https://claude.ai/code/session_011WAs4wTFYFSgQ6ycXcBLjs)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the scan corpus for 2026-05-17. Added results for `merlvintan/damn-vulnerable-llm-agent`, logged a failed scan for `szybnev/DVLA`, and updated aggregates.

- **New Data**
  - Added scan: `merlvintan/damn-vulnerable-llm-agent` — 2 HIGH SQL injection findings in transaction_db.py; governance 27/100; risk 22; EU AI Act readiness PARTIAL.
  - Aggregates updated: total_scans 3, total_findings_observed 11, average_governance_score 19.7, last_refreshed 2026-05-17T19:31:58Z.
  - Recorded failure: `szybnev/DVLA` (HTTP 400 no_agent_code) in `data/scan-corpus-failures.json`.

<sup>Written for commit 1caefd8fe00492bf1eb3a01b7fb973006a7f90dd. Summary will update on new commits. <a href="https://cubic.dev/pr/inkog-io/inkog/pull/26?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

