### PR TITLE
data: scan corpus refresh — 2026-05-24

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Log of failed public scan attempts by the weekly corpus-refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-05-24T19:33:08Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code: repository contains no LLM agent code scannable by Inkog (HTTP 400, error code: no_agent_code)"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-05-24T19:33:08Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-05-24T19:33:08Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "77dd316f-8025-4471-9508-afc24ad3406e",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent**: 2 findings (HIGH ×2), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`.

`szybnev/DVLA` was attempted first but returned `no_agent_code` (HTTP 400); failure logged to `data/scan-corpus-failures.json`. Corpus now at 3 total scans, 11 cumulative findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1gVVvy9RWGGsq5pBchj79)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Weekly corpus refresh adds scan results for `merlvintan/damn-vulnerable-llm-agent` (2 HIGH SQL injection findings; governance 27/100; EU AI Act readiness PARTIAL) and creates `data/scan-corpus-failures.json` to log a skipped scan of `szybnev/DVLA` (`no_agent_code`, HTTP 400).
Updated `data/scan-corpus.json` aggregates to 3 total scans and 11 findings; `last_refreshed` set to 2026-05-24.

<sup>Written for commit d06af8451212576f2efbc4ac71c657441150188a. Summary will update on new commits. <a href="https://cubic.dev/pr/inkog-io/inkog/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

