### PR TITLE
data: scan corpus refresh — 2026-05-31

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Log of scan attempts that failed during corpus refresh routines.",
+  "failures": [
+    {
+      "timestamp": "2026-05-31T19:37:23Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code: repository contains no AI agent code detectable by the scanner (HTTP 400)"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-05-31T19:37:23Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-05-31T19:37:23Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "70301ab2-3e5b-4ad0-a338-65f9d01844d8",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent**: 2 findings (0 critical, 2 high), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`.\n\nAlso logs a failure for `szybnev/DVLA` (no AI agent code detected, HTTP 400) in `data/scan-corpus-failures.json` — new file created this run.\n\nCorpus grows from 2 → 3 scans; aggregate governance score 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft6iy1aNPFUZNCAz1KHUY3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the scan corpus by adding a new result for `merlvintan/damn-vulnerable-llm-agent` and logging a failed attempt for `szybnev/DVLA`. Aggregates and last_refreshed are updated.

- **Data updates**
  - Added scan: `merlvintan/damn-vulnerable-llm-agent` (2 findings: 0 critical, 2 high; governance 27; risk 22; EU AI Act readiness PARTIAL; categories: sql_injection, injection).
  - Created `data/scan-corpus-failures.json`: logged `szybnev/DVLA` failure (no_agent_code, HTTP 400).
  - Updated `data/scan-corpus.json` aggregates: total_scans 3, total_findings_observed 11, average_governance_score 19.67, last_refreshed 2026-05-31T19:37:23Z.

<sup>Written for commit 3d47d9d0c8d8c5d0c332beb3ce42975b1834c83d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

