### PR TITLE
data: scan corpus refresh — 2026-06-07

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,12 @@
+{
+  "_description": "Failed scan attempts during corpus refresh routines. Each entry records the attempted target, timestamp, and failure reason.",
+  "failures": [
+    {
+      "timestamp": "2026-06-07T19:34:31Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code",
+      "http_status": 400,
+      "detail": "API returned error code 'no_agent_code' — repository contains no detectable LLM agent code. Skipped; fallback target used."
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-06-07T19:34:31Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -56,6 +56,25 @@
         "code_injection",
         "governance"
       ]
+    },
+    {
+      "timestamp": "2026-06-07T19:34:31Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "016fb11f-f9b0-42f8-ac6e-01ae9f6a21d6",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection",
+        "governance"
+      ],
+      "frameworks_covered": ["langchain"]
     }
   ]
 }


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent**: 2 findings (HIGH ×2), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated query in `transaction_db.py`. Framework detected: LangChain.

Also adds `data/scan-corpus-failures.json` logging the skipped target `szybnev/DVLA` (API returned `no_agent_code` — no detectable LLM agent code).

Corpus grows from 2 → 3 scans; total findings observed 9 → 11; average governance score 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyqWzNonCUaRrhkozDzs1P)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the scan corpus by adding `merlvintan/damn-vulnerable-llm-agent` and logging a skipped target; updated aggregates. Found 2 HIGH SQL injection issues in `transaction_db.py`.

- **Data Updates**
  - New scan: `merlvintan/damn-vulnerable-llm-agent` — 2 HIGH (SQL injection), governance 27/100, EU AI Act readiness PARTIAL, `langchain` detected.
  - Failure logging: added `data/scan-corpus-failures.json`; recorded skipped `szybnev/DVLA` (400, reason `no_agent_code`).
  - Aggregates: total_scans 3, total_findings_observed 11, average_governance_score 19.67, last_refreshed 2026-06-07T19:34:31Z.

<sup>Written for commit 46c65dffefb341309c5885e0c43f8b1359b317dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

