### PR TITLE
data: scan corpus refresh — 2026-06-14

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,13 @@
+{
+  "_description": "Log of public scan attempts that failed during the weekly corpus refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-06-14T19:32:16Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code",
+      "detail": "API returned HTTP 400: {\"error\":\"no_agent_code\",\"code\":\"no_agent_code\"} — repository contains no scannable agent code",
+      "routine_run": "Routine 6 — 2026-06-14",
+      "fallback_target": "merlvintan/damn-vulnerable-llm-agent"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-06-14T19:32:16Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -54,6 +54,25 @@
         "code_execution",
         "resource_exhaustion",
         "code_injection",
+        "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-06-14T19:32:16Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "5470b414-bff1-4903-b6a7-c6782a1ae5e9",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection",
+        "missing_audit_logging",
         "governance"
       ]
     }


### PR DESCRIPTION
Scanned `merlvintan/damn-vulnerable-llm-agent`: 2 findings (0 critical, 2 high), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`.

`szybnev/DVLA` was attempted first but rejected by the API (`no_agent_code`); logged in `data/scan-corpus-failures.json`.

Corpus now at 3 scans, 11 total findings observed, average governance score 19.67/100.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQPC6f4Bu8gJnK2KnN6ET4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the public scan corpus with a new scan of `merlvintan/damn-vulnerable-llm-agent` and logs a failed attempt for `szybnev/DVLA`. Updates aggregates and the last refreshed timestamp.

- **Data Updates**
  - Added scan for `merlvintan/damn-vulnerable-llm-agent`: 2 high findings (SQL injection), governance 27/100, EU AI Act readiness PARTIAL. Updated in `data/scan-corpus.json`.
  - Logged failed scan for `szybnev/DVLA` (reason: `no_agent_code`) in `data/scan-corpus-failures.json`.
  - Aggregates: total scans 3, total findings 11, average governance 19.67, last_refreshed `2026-06-14T19:32:16Z`.

<sup>Written for commit 86b9ca0e66fef6381d6769be62d5556ec4441626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

