### PR TITLE
data: scan corpus refresh — 2026-06-21

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,12 @@
+{
+  "_description": "Log of public scan attempts that failed during corpus refresh. Used to avoid re-queuing known-bad targets.",
+  "failures": [
+    {
+      "timestamp": "2026-06-21T19:35:33Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code",
+      "http_status": 400,
+      "notes": "API returned {\"error\":\"no_agent_code\"} — repository contains no detectable LLM agent code. Skipped from rotation."
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-06-21T19:35:33Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-06-21T19:35:33Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "9f11fb22-da06-4ecd-8a5b-9a66099d0065",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned `merlvintan/damn-vulnerable-llm-agent`: 2 findings (0 critical, 2 high), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`.

Also adds `data/scan-corpus-failures.json` logging the initial target `szybnev/DVLA` which returned `no_agent_code` (no detectable LLM agent code in that repo).

Corpus grows from 2 → 3 scans; `total_findings_observed` 9 → 11; `average_governance_score` 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_017FeLkEYAQfvd7JQ4VAw3k4)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the public scan corpus: adds results for `merlvintan/damn-vulnerable-llm-agent` (2 high SQL injection findings in `transaction_db.py`) and logs failed target `szybnev/DVLA` (`no_agent_code`, 400) to avoid re-queuing. Aggregates updated: total scans 3, total findings 11, average governance 19.67; last refreshed 2026-06-21T19:35:33Z.

<sup>Written for commit d9baf0caab425e770316782bce6aa4018557af8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

