### PR TITLE
data: scan corpus refresh — 2026-06-28

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,9 @@
+[
+  {
+    "timestamp": "2026-06-28T19:34:00Z",
+    "repo": "szybnev/DVLA",
+    "reason": "API returned HTTP 400: no_agent_code — repository does not contain agent/LLM code",
+    "routine_attempt": 1,
+    "fallback_target": "merlvintan/damn-vulnerable-llm-agent"
+  }
+]

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-06-28T19:35:13Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -56,6 +56,24 @@
         "code_injection",
         "governance"
       ]
+    },
+    {
+      "timestamp": "2026-06-28T19:35:13Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "3f6bce0a-5f69-4bbc-abb4-baf23fab6d58",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
+      ],
+      "frameworks_covered": ["langchain"]
     }
   ]
 }


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent** (LangChain-based DVLA fork): 2 findings, both HIGH-severity SQL injection via LLM-generated queries, governance score 27/100, EU AI Act readiness PARTIAL.

First attempt against `szybnev/DVLA` failed (`no_agent_code` — repo has no LLM/agent code); logged to `data/scan-corpus-failures.json`.

Corpus grows from 2 → 3 scans; `total_findings_observed` 9 → 11; `average_governance_score` 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNnZN7rdbJiJrFGBNJdDyk)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the scan corpus by adding a new scan for `merlvintan/damn-vulnerable-llm-agent` and introducing a failure log for rejected targets. Totals now 3 scans and 11 findings.

- **New Features**
  - Added scan for `merlvintan/damn-vulnerable-llm-agent`: 2 HIGH SQL injection findings; governance 27/100; EU AI Act readiness PARTIAL.
  - Created `data/scan-corpus-failures.json` logging a failed attempt for `szybnev/DVLA` (HTTP 400: no_agent_code) with fallback to `merlvintan/damn-vulnerable-llm-agent`.
  - Updated `data/scan-corpus.json` aggregates: total_scans 3, total_findings_observed 11, average_governance_score 19.67, last_refreshed 2026-06-28.

<sup>Written for commit c855d45318e11dfd37cacb79dba614c01ebec2a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

