### PR TITLE
data: scan corpus refresh — 2026-07-05

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Scan attempt failures logged by the automated corpus refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-07-05T19:34:00Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code — API returned 400: no LLM agent code detected in repository"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,10 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "frameworks_covered": [
+      "langchain"
+    ],
+    "last_refreshed": "2026-07-05T19:35:17Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +58,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-07-05T19:35:17Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "c6504801-84af-49ba-94f6-84f98f09cbec",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent** (2 findings, both HIGH; governance score 27/100; EU AI Act readiness: PARTIAL). Both findings are SQL injection via LLM-generated query in `transaction_db.py`. Framework detected: LangChain.

First attempt on `szybnev/DVLA` failed (400 `no_agent_code` — no LLM agent code detected); `scan-corpus-failures.json` created to track it. Fell through to `merlvintan/damn-vulnerable-llm-agent` per routine failure-handling rules.

Corpus now at 3 total scans, 11 findings observed, average governance score 19.67/100.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNGdezgibXboorXCPWAmbK)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the public scan corpus with a new scan for `merlvintan/damn-vulnerable-llm-agent` (2 HIGH SQL injection), updates aggregates to 3 scans/11 findings/avg governance 19.67, and adds `frameworks_covered: ["langchain"]`. Adds `data/scan-corpus-failures.json` to log failed attempts and records the `szybnev/DVLA` 400 no_agent_code event.

<sup>Written for commit 641fb6a8a54e473a691a438806f4ecc6185c68a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

