### PR TITLE
data: scan corpus refresh — 2026-07-12

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,12 @@
+{
+  "_description": "Failed scan attempts logged by the automated scan-corpus routine.",
+  "failures": [
+    {
+      "timestamp": "2026-07-12T19:35:00Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code — repository contains no LLM agent code detectable by the scanner (HTTP 400: {\"error\":\"no_agent_code\",\"code\":\"no_agent_code\"})",
+      "routine_run": "Routine 6 — 2026-07-12",
+      "action_taken": "Skipped; fell back to merlvintan/damn-vulnerable-llm-agent which scanned successfully."
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.7,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,10 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "frameworks_covered": [
+      "langchain"
+    ],
+    "last_refreshed": "2026-07-12T19:35:14Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +58,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-07-12T19:35:14Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "240745fc-eb2c-400f-bed7-860a508c04cd",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned **merlvintan/damn-vulnerable-llm-agent** (Tier A). Found **2 findings** (0 critical, 2 high, 0 medium, 0 low) — both `sql_injection` via LLM-generated queries in `transaction_db.py`. Governance score **27/100**, EU AI Act readiness **PARTIAL**.

Also adds `data/scan-corpus-failures.json` logging `szybnev/DVLA` as unscannable (`no_agent_code` — no LLM agent code detected); `merlvintan/damn-vulnerable-llm-agent` was the successful fallback pick.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMCQVemWo8waPbkRPQwBL3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the public scan corpus for 2026-07-12 and adds failure logging for unscannable repos.

- **New Features**
  - Added a new scan entry for `merlvintan/damn-vulnerable-llm-agent`: 2 high `sql_injection` findings in `transaction_db.py`; governance 27/100; risk 22; EU AI Act readiness PARTIAL.
  - Updated `data/scan-corpus.json` aggregates (total_scans 3, findings 11, average governance 19.7), added `frameworks_covered: ['langchain']`, refreshed timestamp; added `data/scan-corpus-failures.json` logging `szybnev/DVLA` as `no_agent_code` (fell back to `merlvintan/damn-vulnerable-llm-agent`).

<sup>Written for commit 35e4dfd765a636616440d641f311c9ba46f72c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

