### PR TITLE
data: scan corpus refresh — 2026-07-19

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,19 @@
+{
+  "_description": "Scan failures log — entries added when a public scan attempt returns a non-2xx response or scan engine error.",
+  "failures": [
+    {
+      "timestamp": "2026-07-19T19:33:54Z",
+      "repo": "szybnev/DVLA",
+      "reason": "no_agent_code",
+      "http_status": 400,
+      "detail": "Scanner returned error code 'no_agent_code' — repository contains no detectable LLM agent code."
+    },
+    {
+      "timestamp": "2026-07-19T19:33:54Z",
+      "repo": "KavinduMW/DamnVulnerableLLMProject",
+      "reason": "clone_failed",
+      "http_status": 400,
+      "detail": "Repository not found or private. Only public GitHub repositories are supported."
+    }
+  ]
+}


### PR DESCRIPTION
Both scan targets attempted this week failed; introduces `data/scan-corpus-failures.json` to track them.

- **szybnev/DVLA** — HTTP 400 `no_agent_code`: scanner found no detectable LLM agent code in the repo.
- **KavinduMW/DamnVulnerableLLMProject** — HTTP 400 `clone_failed`: repository not found or is private.

No corpus entry added this week. Rotation will resume next week from the remaining eligible Tier A targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH1omJfkpRFvp9dKoP3WSv)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a failures log for the weekly corpus scan and recorded two failed targets from 2026-07-19. No corpus entries were added this week.

- **New Features**
  - Added `data/scan-corpus-failures.json` to track non-2xx or engine errors (timestamp, repo, reason, status, detail).
  - Logged failures for `szybnev/DVLA` (HTTP 400 `no_agent_code`) and `KavinduMW/DamnVulnerableLLMProject` (HTTP 400 `clone_failed`). Rotation resumes next week.

<sup>Written for commit 78e50a5a4456c868a7bd79cbae3113c9718c8af3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

