### PR TITLE
data: scan corpus refresh — 2026-07-26

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Failed scan attempts logged by the weekly corpus-refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-07-26T19:35:13Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 no_agent_code — repository contains no LLM agent code recognizable by the scanner"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-07-26T19:35:52Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,22 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-07-26T19:35:52Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "56e30771-5dce-4ca6-a7ae-09e907a59122",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection"
       ]
     }
   ]


### PR DESCRIPTION
Adds this week's corpus datapoint from `merlvintan/damn-vulnerable-llm-agent`: 2 findings (HIGH ×2), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated query (CWE-89) in `transaction_db.py`.

Also adds `data/scan-corpus-failures.json` logging the skipped attempt against `szybnev/DVLA` (returned `no_agent_code` — not an LLM agent repo).

Corpus grows from 2 → 3 scans; total findings observed 9 → 11; average governance score 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_019NEjABvd97ifQPM9gRki5m)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the weekly scan corpus and adds a failure log to track skipped scans.
Adds `merlvintan/damn-vulnerable-llm-agent` (2 HIGH SQL injection findings, CWE-89, in `transaction_db.py`; governance 27/100; EU AI Act readiness PARTIAL), updates aggregates (scans 3, findings 11, avg governance 19.67), and records a skipped scan for `szybnev/DVLA` in `data/scan-corpus-failures.json` (reason: no_agent_code).

<sup>Written for commit af96690f09ce736b1dd90b85a92f62a3d2b7fc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

