### PR TITLE
data: scan corpus refresh — 2026-08-02

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -5,6 +5,18 @@
       "timestamp": "2026-07-26T19:35:13Z",
       "repo": "szybnev/DVLA",
       "reason": "HTTP 400 no_agent_code — repository contains no LLM agent code recognizable by the scanner"
+    },
+    {
+      "timestamp": "2026-08-02T19:36:46Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 no_agent_code — repository contains no LLM agent code recognizable by the scanner (second attempt, same result)",
+      "routine_run": "2026-08-02"
+    },
+    {
+      "timestamp": "2026-08-02T19:36:57Z",
+      "repo": "KavinduMW/DamnVulnerableLLMProject",
+      "reason": "HTTP 400 clone_failed — repository not found or private",
+      "routine_run": "2026-08-02"
     }
   ]
 }

--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Failed scan attempts logged by the weekly corpus-refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-07-26T19:35:13Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 no_agent_code — repository contains no LLM agent code recognizable by the scanner"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-07-26T19:35:52Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,22 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-07-26T19:35:52Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "56e30771-5dce-4ca6-a7ae-09e907a59122",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection"
       ]
     }
   ]


### PR DESCRIPTION
Both scan attempts this week failed — no new corpus entry added.

- **szybnev/DVLA**: `no_agent_code` (second consecutive week; repo has no LLM agent code recognizable by the scanner — remove from rotation list)
- **KavinduMW/DamnVulnerableLLMProject**: `clone_failed` — repo is not found or has been made private

Only change is `data/scan-corpus-failures.json` updated with both failure records. Next eligible targets are `ReversecLabs/damn-vulnerable-llm-agent` and `harishsg993010/DamnVulnerableLLMProject` (both last scanned in May 2026).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfroQsnhyPgPUzShbj2QEP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs failed scans for the 2026-08-02 refresh (no_agent_code for `szybnev/DVLA`, clone_failed for `KavinduMW/DamnVulnerableLLMProject`) and updates `data/scan-corpus.json` with the 2026-07-26 scan of `merlvintan/damn-vulnerable-llm-agent` and refreshed aggregates. Adds `data/scan-corpus-failures.json`; no new corpus entry for 2026-08-02.

<sup>Written for commit c51fcf27f95b12b7ca16b4864b5b65c1c23b433d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

