### PR TITLE
data: scan corpus refresh — 2026-08-16

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,9 @@
+{
+  "failures": [
+    {
+      "timestamp": "2026-08-16T19:35:35Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 no_agent_code — repository does not contain AI agent code recognised by the scanner"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-08-16T19:35:35Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,23 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-08-16T19:34:54Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "b64785f2-7dbe-42ae-8efd-78a3bf04c1eb",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Adds this week's corpus scan for `merlvintan/damn-vulnerable-llm-agent` (fallback from `szybnev/DVLA`, which returned `no_agent_code`). 2 findings (both HIGH), all SQL injection via LLM-generated queries; governance score 27/100, EU AI Act readiness PARTIAL. Corpus is now 3 scans, 11 total findings observed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DGSfc6DroscAndgZYdMYi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the public scan corpus with the 2026-08-16 run and adds a failure log for `szybnev/DVLA`. This updates aggregates and introduces `data/scan-corpus-failures.json` for tracking scan failures.

The new scan targets `merlvintan/damn-vulnerable-llm-agent` (fallback after `szybnev/DVLA` returned `no_agent_code`) and reports 2 HIGH SQL injection findings; governance score 27; EU AI Act readiness PARTIAL.

**Review Notes**
- Aggregates changed: total_scans 2→3, total_findings_observed 9→11, average_governance_score 16.0→19.67; `last_refreshed` updated.
- New `data/scan-corpus-failures.json` with `{ failures: [{ timestamp, repo, reason }] }`; ensure ingestion jobs tolerate and, if needed, consume this file.
- Update any dashboards or metrics derived from `data/scan-corpus.json` to include the new scan entry and revised counts.

<sup>Written for commit 41e4c889da115174008f3833753dd28b8b884e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

