### PR TITLE
data: scan corpus refresh — 2026-08-23

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,14 @@
+{
+  "failures": [
+    {
+      "timestamp": "2026-08-16T19:35:35Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 no_agent_code — repository does not contain AI agent code recognised by the scanner"
+    },
+    {
+      "timestamp": "2026-08-23T19:35:56Z",
+      "repo": "KavinduMW/DamnVulnerableLLMProject",
+      "reason": "HTTP 400 clone_failed — Repository not found or private"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 4,
+    "total_findings_observed": 13,
+    "average_governance_score": 21.5,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-08-23T19:35:56Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -55,6 +55,40 @@
         "resource_exhaustion",
         "code_injection",
         "governance"
+      ]
+    },
+    {
+      "timestamp": "2026-08-16T19:34:54Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "b64785f2-7dbe-42ae-8efd-78a3bf04c1eb",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
+      ]
+    },
+    {
+      "timestamp": "2026-08-23T19:35:56Z",
+      "repo": "ReversecLabs/damn-vulnerable-llm-agent",
+      "report_id": "7a25694e-752b-4a41-838b-3945402c73c7",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
       ]
     }
   ]


### PR DESCRIPTION
Scanned **ReversecLabs/damn-vulnerable-llm-agent**: 2 findings (2 HIGH — SQL injection via LLM-generated query in `transaction_db.py`), governance score 27/100, EU AI Act readiness PARTIAL.

Also carries forward the merlvintan entry from the unmerged 2026-08-16 branch and logs two scan failures: `szybnev/DVLA` (no agent code) and `KavinduMW/DamnVulnerableLLMProject` (repo not found/private).

Corpus grows from 2 → 4 entries; total findings observed 9 → 13; average governance score 16.0 → 21.5.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUXLx6vpLKxFBLfG5zgYum)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the scan corpus and adds a failure log so weekly reporting captures both successful and failed scans. Previously only successful scans were recorded; now `data/scan-corpus-failures.json` tracks failures, and aggregates reflect two newly included repos.

- Append scans for `merlvintan/damn-vulnerable-llm-agent` (carried forward from 2026-08-16) and `ReversecLabs/damn-vulnerable-llm-agent` (2 HIGH findings each; governance 27; EU AI Act readiness PARTIAL).
- Update aggregates in `data/scan-corpus.json`: total_scans 2→4, total_findings_observed 9→13, average_governance_score 16.0→21.5, last_refreshed 2026-08-23T19:35:56Z.
- Add `data/scan-corpus-failures.json` with failures for `szybnev/DVLA` (no_agent_code) and `KavinduMW/DamnVulnerableLLMProject` (clone_failed). No schema changes; no migration required.

<sup>Written for commit 581f3d8e9ae42215424750f2a4c5eb3c027f21ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

