### PR TITLE
data: scan corpus refresh — 2026-08-30

### DIFF
--- a/data/scan-corpus-failures.json
+++ b/data/scan-corpus-failures.json
@@ -1,0 +1,10 @@
+{
+  "_description": "Failed scan attempts logged by the weekly corpus refresh routine.",
+  "failures": [
+    {
+      "timestamp": "2026-08-30T19:35:03Z",
+      "repo": "szybnev/DVLA",
+      "reason": "HTTP 400 from scan-public API"
+    }
+  ]
+}

--- a/data/scan-corpus.json
+++ b/data/scan-corpus.json
@@ -3,9 +3,9 @@
   "_description": "Public scan corpus — the live dataset behind State of AI Agent Security 2026. Refreshed weekly by an automated routine.",
   "_methodology": "See data/scan-corpus-readme.md for methodology, included repo criteria, and rotation cadence.",
   "aggregates": {
-    "total_scans": 2,
-    "total_findings_observed": 9,
-    "average_governance_score": 16.0,
+    "total_scans": 3,
+    "total_findings_observed": 11,
+    "average_governance_score": 19.67,
     "finding_categories_aggregated": [
       "sql_injection",
       "injection",
@@ -15,7 +15,7 @@
       "resource_exhaustion",
       "code_injection"
     ],
-    "last_refreshed": "2026-05-10T19:35:03Z",
+    "last_refreshed": "2026-08-30T19:35:14Z",
     "first_scan_date": "2026-05-04T12:10:06Z"
   },
   "scans": [
@@ -56,6 +56,24 @@
         "code_injection",
         "governance"
       ]
+    },
+    {
+      "timestamp": "2026-08-30T19:35:14Z",
+      "repo": "merlvintan/damn-vulnerable-llm-agent",
+      "report_id": "c1253198-8871-4a0c-8a95-b5507672a32c",
+      "findings_count": 2,
+      "critical_count": 0,
+      "high_count": 2,
+      "medium_count": 0,
+      "low_count": 0,
+      "governance_score": 27,
+      "risk_score": 22,
+      "eu_ai_act_readiness": "PARTIAL",
+      "top_finding_categories": [
+        "sql_injection",
+        "injection"
+      ],
+      "frameworks_covered": ["langchain"]
     }
   ]
 }


### PR DESCRIPTION
Scanned `merlvintan/damn-vulnerable-llm-agent`: 2 findings (0 CRIT, 2 HIGH, 0 MED, 0 LOW), governance score 27/100, EU AI Act readiness PARTIAL. Both findings are SQL injection via LLM-generated queries in `transaction_db.py`. Agent framework: LangChain.

Also adds `data/scan-corpus-failures.json` logging `szybnev/DVLA` (HTTP 400 on first attempt); `merlvintan/damn-vulnerable-llm-agent` was the fallback pick.

Corpus: 2 → 3 entries. Total findings observed: 9 → 11. Average governance score: 16.0 → 19.67.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmDX99PT35NdW2UC2NUEkg)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the weekly corpus scan for `merlvintan/damn-vulnerable-llm-agent` and logs a failed attempt for `szybnev/DVLA`.

- Records 2 HIGH SQL injection findings, governance score 27/100, and PARTIAL EU AI Act readiness.
- Updates aggregates: corpus 2→3, total findings 9→11, average governance score 16.0→19.67.
- New `data/scan-corpus-failures.json` tracks the HTTP 400 from the `szybnev/DVLA` scan attempt.

<sup>Written for commit 3568c7316b4b54dbdc3cb13f7485ffab972d245b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

