### PR TITLE
chore(changelog): v1.2.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ Initial public release.
 - **Multi-framework support** — LangChain, LangGraph, CrewAI, AutoGen, OpenAI Agents, Semantic Kernel, LlamaIndex, Haystack, DSPy, Phidata, Smolagents, PydanticAI, Google ADK, n8n, Flowise, Langflow, Dify, Microsoft Copilot Studio, Salesforce Agentforce.
 - **Cross-platform builds** — darwin (amd64, arm64), linux (amd64, arm64), windows (amd64).
 
-[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/inkog-io/inkog/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/inkog-io/inkog/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/inkog-io/inkog/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/inkog-io/inkog/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
Updates the version-compare footer links in CHANGELOG.md to close out the v1.2.2 release cycle. The [1.2.2] section content was already committed during development (c5e8d37); this PR wires the Keep a Changelog footer anchors so they resolve correctly.

See the [v1.2.2 GitHub release](https://github.com/inkog-io/inkog/releases/tag/v1.2.2) for the full release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ngKFn6pFyBSbCT6GrLfiM

---
_Generated by [Claude Code](https://claude.ai/code/session_016ngKFn6pFyBSbCT6GrLfiM)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CHANGELOG footer so the v1.2.2 release notes resolve correctly: adds the `[1.2.2]` version-compare link and points `[Unreleased]` at `v1.2.2...HEAD`. The release section content was already committed; this closes out the release cycle.

<sup>Written for commit 73e6e20e8ee559257cb3e0cc9700fa14bb12c07c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

