### PR TITLE
chore(changelog): v1.2.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,9 @@ Initial public release.
 - **Multi-framework support** — LangChain, LangGraph, CrewAI, AutoGen, OpenAI Agents, Semantic Kernel, LlamaIndex, Haystack, DSPy, Phidata, Smolagents, PydanticAI, Google ADK, n8n, Flowise, Langflow, Dify, Microsoft Copilot Studio, Salesforce Agentforce.
 - **Cross-platform builds** — darwin (amd64, arm64), linux (amd64, arm64), windows (amd64).
 
-[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/inkog-io/inkog/compare/v1.2.3...HEAD
+[1.2.3]: https://github.com/inkog-io/inkog/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/inkog-io/inkog/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/inkog-io/inkog/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/inkog-io/inkog/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/inkog-io/inkog/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
Adds the missing version-compare footer links for `[1.2.2]` and `[1.2.3]` to CHANGELOG.md, and updates `[Unreleased]` to compare from `v1.2.3...HEAD`.

The sections for both versions were already written in the file; only the link table at the bottom was out of date.

Release page: https://github.com/inkog-io/inkog/releases/tag/v1.2.3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7zLhcn6vWBh6imc2tVpPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7zLhcn6vWBh6imc2tVpPT)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CHANGELOG version-compare links for the v1.2.3 release. Adds the missing `[1.2.2]` and `[1.2.3]` links and points `[Unreleased]` at `v1.2.3...HEAD`.

<sup>Written for commit d74024bdab9efff63767e3ad54caaa30925d185a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/inkog-io/inkog/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

